### PR TITLE
Fix point packing

### DIFF
--- a/src/main/java/io/vram/dtk/PackedPoint2i.java
+++ b/src/main/java/io/vram/dtk/PackedPoint2i.java
@@ -30,6 +30,6 @@ public class PackedPoint2i {
 	}
 
 	public static long pack(int x, int y) {
-		return x | (((long) y) << 32);
+		return (x & 0xFFFFFFFFL) | (((long) y) << 32);
 	}
 }


### PR DESCRIPTION
I don't get Java's type casting, but that's what this fix is about, I think.

Explanation from [this post](https://stackoverflow.com/questions/12772939/java-storing-two-ints-in-a-long) (paraphrased): casting int to long will extend the sign bit, therefore truncating is necessary.